### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/AppLovinAdapterBannerAd.swift
+++ b/Source/AppLovinAdapterBannerAd.swift
@@ -49,7 +49,7 @@ extension AppLovinAdapterBannerAd: ALAdLoadDelegate {
     }
 
     func adService(_ adService: ALAdService, didFailToLoadAdWithError code: Int32) {
-        let error = error(.loadFailureUnknown, description: "\(code)")
+        let error = partnerError(Int(code))
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil

--- a/Source/AppLovinAdapterInterstitialAd.swift
+++ b/Source/AppLovinAdapterInterstitialAd.swift
@@ -61,7 +61,7 @@ extension AppLovinAdapterInterstitialAd: ALAdLoadDelegate {
     }
 
     func adService(_ adService: ALAdService, didFailToLoadAdWithError code: Int32) {
-        let error = error(.loadFailureUnknown, description: "\(code)")
+        let error = partnerError(Int(code))
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
