### PR TITLE
Replace deprecated property by new one

### DIFF
--- a/Source/AppLovinAdapterConfiguration.swift
+++ b/Source/AppLovinAdapterConfiguration.swift
@@ -55,7 +55,7 @@ extension AppLovinAdapterConfiguration {
 
     static func syncVerboseLogging() {
         guard let sdk = Self.sdk else { return }
-        sdk.settings.isVerboseLogging = verboseLogging
+        sdk.settings.isVerboseLoggingEnabled = verboseLogging
         print("AppLovin SDK verbose logging set to \(verboseLogging)")
     }
 }


### PR DESCRIPTION
The deprecation warning is making our nightly builds fail.