### PR TITLE
HB-5214: Guard against integer underflow when mapping errors

### DIFF
--- a/Source/AppLovinAdapter.swift
+++ b/Source/AppLovinAdapter.swift
@@ -137,7 +137,11 @@ final class AppLovinAdapter: PartnerAdapter {
     /// Only implement if the partner SDK provides its own list of error codes that can be mapped to Chartboost Mediation's.
     /// If some case cannot be mapped return `nil` to let Chartboost Mediation choose a default error code.
     func mapLoadError(_ error: Error) -> ChartboostMediationError.Code? {
-        switch Int32((error as NSError).code) {
+        guard let errorCode = Int32(exactly: (error as NSError).code) else {
+            return nil
+        }
+
+        switch errorCode {
         case kALErrorCodeSdkDisabled:
             return .loadFailureAborted
         case kALErrorCodeNoFill:


### PR DESCRIPTION
I was getting an SSL error with the error code `-1200`, which was causing a crash due to integer underflow. This change will protect against both underflow and overflow. This change has been made to all adapters that convert to `Int32` or `UInt32`.