### PR TITLE
HB-5511: lower minimum AppLovin version to 11.5.5 for ZADE

### DIFF
--- a/ChartboostMediationAdapterAppLovin.podspec
+++ b/ChartboostMediationAdapterAppLovin.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'AppLovinSDK', '~> 11.7.0'
+  spec.dependency 'AppLovinSDK', '~> 11.5.5'
 end


### PR DESCRIPTION
Adapter release process doc: https://chartboost.atlassian.net/wiki/spaces/HM/pages/2484174870/Adapter+Development+Guide