### PR TITLE
HB-5511: [4.11.7.0.1] lower minimum AppLovin version to 11.5.5 for ZADE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,8 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 ### 4.11.7.0.0
 - This version of the adapters has been certified with AppLovinSDK 11.7.0.
 
+### 4.11.5.5.0
+- This version of the adapters has been certified with AppLovinSDK 11.5.5.
+
 ### 4.11.5.4.0
 - This version of the adapters has been certified with AppLovinSDK 11.5.4.

--- a/ChartboostMediationAdapterAppLovin.podspec
+++ b/ChartboostMediationAdapterAppLovin.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'AppLovinSDK', '~> 11.7.0'
+  spec.dependency 'AppLovinSDK', '11.5.5'
 end


### PR DESCRIPTION
Adapter release process doc: https://chartboost.atlassian.net/wiki/spaces/HM/pages/2484174870/Adapter+Development+Guide