### PR TITLE
HB-5511: [4.11.5.5.0] lower minimum AppLovin version to 11.5.5 for ZADE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,8 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 ### 4.11.7.0.0
 - This version of the adapters has been certified with AppLovinSDK 11.7.0.
 
+### 4.11.5.5.0
+- This version of the adapters has been certified with AppLovinSDK 11.5.5.
+
 ### 4.11.5.4.0
 - This version of the adapters has been certified with AppLovinSDK 11.5.4.

--- a/ChartboostMediationAdapterAppLovin.podspec
+++ b/ChartboostMediationAdapterAppLovin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterAppLovin'
-  spec.version     = '4.11.8.0.0'
+  spec.version     = '4.11.5.5.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-applovin'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,5 +24,5 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'AppLovinSDK', '~> 11.8.0'
+  spec.dependency 'AppLovinSDK', '11.5.5'
 end

--- a/Source/AppLovinAdapter.swift
+++ b/Source/AppLovinAdapter.swift
@@ -17,7 +17,7 @@ final class AppLovinAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.11.8.0.0"
+    let adapterVersion = "4.11.5.5.0"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "applovin"


### PR DESCRIPTION
Adapter release process doc: https://chartboost.atlassian.net/wiki/spaces/HM/pages/2484174870/Adapter+Development+Guide