### PR TITLE
HB-5462: Support new ad format cases without warnings

### DIFF
--- a/Source/AppLovinAdapter.swift
+++ b/Source/AppLovinAdapter.swift
@@ -125,7 +125,7 @@ final class AppLovinAdapter: PartnerAdapter {
             return AppLovinAdapterInterstitialAd(sdk: sdk, adapter: self, request: request, delegate: delegate)
         case .rewarded:
             return AppLovinAdapterRewardedAd(sdk: sdk, adapter: self, request: request, delegate: delegate)
-        @unknown default:
+        default:
             throw error(.loadFailureUnsupportedAdFormat)
         }
     }


### PR DESCRIPTION
Removed the  keyword from the default case when switching on ad format, preventing warnings when new formats are introduced on newer Chartboost Mediation SDK versions.\nThe plan is to just merge this to main, and create new patch releases later on with the first 4.3 RCs with whatever the latest adapter version is.