### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/AppLovinAdapter.swift
+++ b/Source/AppLovinAdapter.swift
@@ -13,18 +13,26 @@ import AdSupport
 final class AppLovinAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    let partnerSDKVersion = ALSdk.version()
-    
+    var partnerSDKVersion: String {
+        AppLovinAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.12.4.0.0"
-    
+    var adapterVersion: String {
+        AppLovinAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "applovin"
-    
+    var partnerID: String {
+        AppLovinAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "AppLovin"
+    var partnerDisplayName: String {
+        AppLovinAdapterConfiguration.partnerDisplayName
+    }
     
     /// Instance of the AppLovin SDK
     let sdk: ALSdk = ALSdk.shared()

--- a/Source/AppLovinAdapterConfiguration.swift
+++ b/Source/AppLovinAdapterConfiguration.swift
@@ -10,6 +10,22 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class AppLovinAdapterConfiguration: NSObject {
     
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        ALSdk.version()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.12.4.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "applovin"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "AppLovin"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.applovin", category: "Configuration")
 
     /// Flag that can optionally be set to enable the partner's test mode.

--- a/Source/AppLovinAdapterConfiguration.swift
+++ b/Source/AppLovinAdapterConfiguration.swift
@@ -11,20 +11,20 @@ import os.log
 @objc public class AppLovinAdapterConfiguration: NSObject {
     
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         ALSdk.version()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.12.4.0.0"
+    @objc public static let adapterVersion = "4.12.4.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "applovin"
+    @objc public static let partnerID = "applovin"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "AppLovin"
+    @objc public static let partnerDisplayName = "AppLovin"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.applovin", category: "Configuration")
 

--- a/Source/AppLovinAdapterConfiguration.swift
+++ b/Source/AppLovinAdapterConfiguration.swift
@@ -31,7 +31,15 @@ import os.log
     /// Flag that can optionally be set to enable the partner's test mode.
     /// Disabled by default.
     @objc public static var testMode: Bool = false
-    
+
+    /// Flag that can optionally be set to disable the partner's audio.
+    /// Disabled by default.
+    @objc public static var isMuted: Bool = false {
+        didSet {
+            syncIsMuted()
+        }
+    }
+
     /// Flag that can optionally be set to enable the partner's verbose logging.
     /// Disabled by default.
     @objc public static var verboseLogging: Bool = false {
@@ -53,24 +61,26 @@ import os.log
 extension AppLovinAdapterConfiguration {
     
     /// The AppLovin SDK instance
-    static let sdk: ALSdk = ALSdk.shared()
+    private static let sdk: ALSdk = ALSdk.shared()
 
     static func sync() {
         syncVerboseLogging()
         syncLocationCollection()
+        syncIsMuted()
     }
 
-    static func syncVerboseLogging() {
+    private static func syncVerboseLogging() {
         sdk.settings.isVerboseLoggingEnabled = verboseLogging
-        if #available(iOS 12.0, *) {
-            os_log(.debug, log: log, "AppLovin SDK verbose logging set to %{public}s", "\(verboseLogging)")
-        }
+        os_log(.debug, log: log, "AppLovin SDK verbose logging set to %{public}s", "\(verboseLogging)")
     }
 
-    static func syncLocationCollection() {
+    private static func syncLocationCollection() {
         sdk.settings.isLocationCollectionEnabled = locationCollection
-        if #available(iOS 12.0, *) {
-            os_log(.debug, log: log, "AppLovin SDK location collection set to %{public}s", "\(locationCollection)")
-        }
+        os_log(.debug, log: log, "AppLovin SDK location collection set to %{public}s", "\(locationCollection)")
+    }
+
+    private static func syncIsMuted() {
+        sdk.settings.isMuted = isMuted
+        os_log(.debug, log: log, "AppLovin SDK isMuted set to %{public}s", "\(isMuted)")
     }
 }


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.