### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/Source/AppLovinAdapterBannerAd.swift
+++ b/Source/AppLovinAdapterBannerAd.swift
@@ -77,23 +77,28 @@ extension AppLovinAdapterBannerAd: ALAdDisplayDelegate {
 // MARK: - Helpers
 extension AppLovinAdapterBannerAd {
     private func fixedBannerSize(for requestedSize: BannerSize?) -> (size: CGSize, partnerSize: ALAdSize)? {
+        // Return a default value if no size is specified
         guard let requestedSize else {
-            return (IABStandardAdSize, .banner)
+            return (BannerSize.standard.size, .banner)
         }
-        let sizes: [(size: CGSize, partnerSize: ALAdSize)] = [
-            (size: IABLeaderboardAdSize, partnerSize: .leader),
-            (size: IABMediumAdSize, partnerSize: .mrec),
-            (size: IABStandardAdSize, partnerSize: .banner)
-        ]
-        // Find the largest size that can fit in the requested size.
-        for (size, partnerSize) in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return (size, partnerSize)
+
+        // If we can find a size that fits, return that.
+        if let size = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize) {
+            switch size {
+            case .standard:
+                return (BannerSize.standard.size, .banner)
+            case .medium:
+                return (BannerSize.medium.size, .mrec)
+            case .leaderboard:
+                return (BannerSize.leaderboard.size, .leader)
+            default:
+                // largestStandardFixedSizeThatFits currently only returns .standard, .medium, or .leaderboard,
+                // but if that changes then just default to .standard until this code gets updated.
+                return (BannerSize.standard.size, .banner)
             }
+        } else {
+            // largestStandardFixedSizeThatFits has returned nil to indicate it couldn't find a fit.
+            return nil
         }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }

--- a/Source/AppLovinAdapterConfiguration.swift
+++ b/Source/AppLovinAdapterConfiguration.swift
@@ -18,7 +18,7 @@ import os.log
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.12.4.0.0"
+    @objc public static let adapterVersion = "5.12.4.0.0"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "applovin"


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)